### PR TITLE
Set optionally the user's password with a crypted value

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,13 @@ sftp_users:
       - 'beautiful_public_key'
     skeleton: '/etc/skels/sftp-users' *optional*
     shell: '/bin/false' *optional*
+    password: 'password_crypted_value' *optional*
     state: 'present' *optional*
 ```
 
 - *sftp_users_skeleton* is the default skel if not defined in user entry.
 - *sftp_users_shell* is the default shell if not defined in user entry.
+- *sftp_users_password* is the default password if not defined in user entry (a disabled password).
 - *present* is the default user state value.
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,4 @@ sftp_users_home_mode: '0750'
 sftp_users_skeleton: '/etc/skel'
 sftp_users_shell: '/usr/sbin/nologin'
 sftp_users: []
+sftp_users_password: '!'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 # Main tasks file for sftp role
 
 - name: 'INIT | Manage variables to use for our target'
-  include_tasks: "{{ role_path }}/tasks/manage_variables.yml"
+  include: "{{ role_path }}/tasks/manage_variables.yml"
   tags:
     - 'role::sftp'
     - 'role::sftp::init'
@@ -42,6 +42,7 @@
     skeleton: "{{ item.skeleton | default(sftp_users_skeleton) }}"
     state: "{{ item.state | default('present') }}"
     shell: "{{ item.shell | default(sftp_users_shell) }}"
+    password: "{{ item.password | default(sftp_users_password) }}"
   no_log: True
   with_items: "{{ sftp_users }}"
   tags:


### PR DESCRIPTION
Add the ability to use a password when not using public key autentication, the preferred way, (eg: on legacy systems). 
This pull request gives the ability to specify a password in a crypted form, eg:
password: '$6$MMYYL4ThBz9HMDm$4bc4Hy52FiKmDyeqOwaMPiqVRzJi6aWnv67EO1tnwuVpaJDKfQ0hOiXto3yuXMQS76KZ6FswXmF823Xra9EQX1'